### PR TITLE
Feat add file change tracking and patching

### DIFF
--- a/app/components/chat/Artifact.tsx
+++ b/app/components/chat/Artifact.tsx
@@ -232,7 +232,57 @@ async function handleButtonAction(action: ButtonAction) {
 
 const ActionList = memo(({ actions }: ActionListProps) => {
   const [clickedButtons, setClickedButtons] = useState<Set<string>>(new Set());
-  const [skipClicked, setSkipClicked] = useState(false); // Nouvel état pour suivre si "Ignorer" a été cliqué
+  const [skipClicked, setSkipClicked] = useState(false);
+  
+  // Add a state to track file existence status
+  const [fileExistenceStatus, setFileExistenceStatus] = useState<Record<string, boolean>>({});
+  
+  // Check if files exist when component mounts or when actions change
+  useEffect(() => {
+    const checkFileExistence = async () => {
+      const fileActions = actions.filter(action => action.type === 'file');
+      const newStatus: Record<string, boolean> = {};
+      
+      for (const action of fileActions) {
+        if (action.type === 'file') {
+          try {
+            // Get the artifact that contains the action runner
+            const artifacts = workbenchStore.artifacts.get();
+            let runner = null;
+            
+            // Find the artifact that has this action
+            for (const artifactId in artifacts) {
+              const artifact = artifacts[artifactId];
+              if (artifact.runner && artifact.runner.actions) {
+                const actionIds = Object.keys(artifact.runner.actions.get());
+                // Check if this runner contains our action
+                if (actionIds.some(id => artifact.runner.actions.get()[id] === action)) {
+                  runner = artifact.runner;
+                  break;
+                }
+              }
+            }
+            
+            if (runner && runner.getFileHistory) {
+              // Check if file exists by trying to get its history
+              const history = await runner.getFileHistory((action as any).filePath);
+              newStatus[(action as any).filePath] = !!history;
+            } else {
+              // If we can't get the runner or it doesn't have getFileHistory, assume file is new
+              newStatus[(action as any).filePath] = false;
+            }
+          } catch (error) {
+            console.error('Error checking file existence:', error);
+            newStatus[(action as any).filePath] = false;
+          }
+        }
+      }
+      
+      setFileExistenceStatus(newStatus);
+    };
+    
+    checkFileExistence();
+  }, [actions]);
 
   const handleButtonClick = (action: ButtonAction) => {
     const buttonId = `${action.artifactId}-${action.value}`;
@@ -365,7 +415,8 @@ const ActionList = memo(({ actions }: ActionListProps) => {
                 {
                   type === 'file' ? (
                     <div>
-                      Create{' '}
+                      {/* Show "Create" or "Modify" based on file existence */}
+                      {fileExistenceStatus[(action as any).filePath] ? 'Modify' : 'Create'}{' '}
                       <code
                         className="bg-bolt-elements-artifacts-inlineCode-background text-bolt-elements-artifacts-inlineCode-text px-1.5 py-1 rounded-md text-bolt-elements-item-contentAccent hover:underline cursor-pointer"
                         onClick={() => openArtifactInWorkbench((action as any).filePath)}

--- a/app/components/workbench/FileTree.tsx
+++ b/app/components/workbench/FileTree.tsx
@@ -12,7 +12,7 @@ import { path } from '~/utils/path';
 const logger = createScopedLogger('FileTree');
 
 const NODE_PADDING_LEFT = 8;
-const DEFAULT_HIDDEN_FILES = [/\/node_modules\//, /\/\.next/, /\/\.astro/];
+const DEFAULT_HIDDEN_FILES = [/\/node_modules\//, /\/\.next/, /\/\.astro/, /\/\.history/];
 
 interface Props {
   files?: FileMap;

--- a/app/lib/stores/workbench.ts
+++ b/app/lib/stores/workbench.ts
@@ -38,6 +38,9 @@ type Artifacts = MapStore<Record<string, ArtifactState>>;
 export type WorkbenchViewType = 'code' | 'diff' | 'preview';
 
 export class WorkbenchStore {
+  getActionRunner() {
+    throw new Error('Method not implemented.');
+  }
   #previewsStore = new PreviewsStore(webcontainer);
   #filesStore = new FilesStore(webcontainer);
   #editorStore = new EditorStore(this.#filesStore);


### PR DESCRIPTION
## ✨ Nouvelle fonctionnalité : Suivi des changements de fichiers & application de patchs

---

### 📌 Description

Cette PR introduit un système avancé de **suivi des modifications de fichiers** et de **patching intelligent** dans le runtime de NeuroCode.

---

### 🔧 Changements principaux

#### 📜 Suivi de l’historique des fichiers (`trackFileChange`)
- Enregistrement automatique de l’historique d’un fichier après modification.
- Structure de l’historique :
  - `originalContent`
  - `lastModified`
  - `changeSource` (`user`, `auto-save`, `external`)
  - `versions` (max 10 pour éviter la surcharge)
  - `changes` calculés via `diffLines`.

#### 🩹 Application de patchs intelligents
- Avant toute écriture de fichier :
  - Tentative de création et d’application d’un patch (`createTwoFilesPatch` + `applyPatch`).
  - En cas d’échec : fallback vers une écriture brute.
- Permet de réduire les opérations destructrices et d'optimiser la persistance des changements.

#### 👀 Détection de l’existence d’un fichier
- Dans le composant `Artifact.tsx`, les actions affichent désormais :
  - **"Create"** si le fichier est nouveau.
  - **"Modify"** s’il existe déjà (déterminé via `getFileHistory`).

#### 🗂️ Mise à jour de la gestion des fichiers cachés
- Ajout de `.history` à `DEFAULT_HIDDEN_FILES` dans `FileTree.tsx` pour ne pas l'afficher dans l’arborescence utilisateur.

#### 🚧 Préparation à l’évolution du système
- Ajout du stub `getActionRunner` dans `WorkbenchStore` (non implémenté pour l’instant, mais prêt pour usage futur).

---

### ✅ Avantages

- 🔎 **Transparence** : meilleure visibilité sur les modifications apportées aux fichiers.
- 💡 **Robustesse** : fallback en cas d’échec de patch = pas de plantage.
- 🧠 **Extensibilité** : base solide pour un futur système de "versioning", d’historique visuel ou d’annulation.

---

### 📝 À faire / Suggestions futures

- [ ] Ajouter des tests unitaires/automatisés pour `trackFileChange`.
- [ ] Intégrer une UI de comparaison d'historiques (type diff viewer ?).
- [ ] Implémenter `getActionRunner` dans le `WorkbenchStore`.

---

### 📎 Aucun ticket lié pour le moment.

---