### PR TITLE
feat(model-selector): add filter to show only free models

### DIFF
--- a/app/components/chat/ModelSelector.tsx
+++ b/app/components/chat/ModelSelector.tsx
@@ -28,6 +28,7 @@ export const ModelSelector = ({
   const [modelSearchQuery, setModelSearchQuery] = useState('');
   const [isModelDropdownOpen, setIsModelDropdownOpen] = useState(false);
   const [focusedIndex, setFocusedIndex] = useState(-1);
+  const [showFreeModelsOnly, setShowFreeModelsOnly] = useState(false);
   const searchInputRef = useRef<HTMLInputElement>(null);
   const optionsRef = useRef<(HTMLDivElement | null)[]>([]);
   const dropdownRef = useRef<HTMLDivElement>(null);
@@ -45,9 +46,10 @@ export const ModelSelector = ({
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, []);
 
-  // Filter models based on search query
+  // Filter models based on search query and free filter
   const filteredModels = [...modelList]
     .filter((e) => e.provider === provider?.name && e.name)
+    .filter((model) => !showFreeModelsOnly || model.free === true)
     .filter(
       (model) =>
         model.label.toLowerCase().includes(modelSearchQuery.toLowerCase()) ||
@@ -251,6 +253,21 @@ export const ModelSelector = ({
                 <div className="absolute left-2.5 top-1/2 -translate-y-1/2">
                   <span className="i-ph:magnifying-glass text-bolt-elements-textTertiary" />
                 </div>
+              </div>
+              <div className="mt-2 flex items-center">
+                <label className="flex items-center text-sm text-bolt-elements-textPrimary cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={showFreeModelsOnly}
+                    onChange={(e) => {
+                      setShowFreeModelsOnly(e.target.checked);
+                      setFocusedIndex(-1);
+                    }}
+                    onClick={(e) => e.stopPropagation()}
+                    className="mr-2 h-4 w-4 rounded border-bolt-elements-borderColor text-bolt-elements-focus focus:ring-bolt-elements-focus"
+                  />
+                  Afficher uniquement les modèles gratuits
+                </label>
               </div>
             </div>
 

--- a/app/lib/modules/llm/providers/open-router.ts
+++ b/app/lib/modules/llm/providers/open-router.ts
@@ -32,45 +32,52 @@ export default class OpenRouterProvider extends BaseProvider {
       label: 'Anthropic: Claude 3.5 Sonnet (OpenRouter)',
       provider: 'OpenRouter',
       maxTokenAllowed: 8000,
+      free: false,
     },
     {
       name: 'anthropic/claude-3-haiku',
       label: 'Anthropic: Claude 3 Haiku (OpenRouter)',
       provider: 'OpenRouter',
       maxTokenAllowed: 8000,
+      free: false,
     },
     {
       name: 'deepseek/deepseek-coder',
       label: 'Deepseek-Coder V2 236B (OpenRouter)',
       provider: 'OpenRouter',
       maxTokenAllowed: 8000,
+      free: false,
     },
     {
       name: 'google/gemini-flash-1.5',
       label: 'Google Gemini Flash 1.5 (OpenRouter)',
       provider: 'OpenRouter',
       maxTokenAllowed: 8000,
+      free: false,
     },
     {
       name: 'google/gemini-pro-1.5',
       label: 'Google Gemini Pro 1.5 (OpenRouter)',
       provider: 'OpenRouter',
       maxTokenAllowed: 8000,
+      free: false,
     },
-    { name: 'x-ai/grok-beta', label: 'xAI Grok Beta (OpenRouter)', provider: 'OpenRouter', maxTokenAllowed: 8000 },
+    { name: 'x-ai/grok-beta', label: 'xAI Grok Beta (OpenRouter)', provider: 'OpenRouter', maxTokenAllowed: 8000, free: false },
     {
       name: 'mistralai/mistral-nemo',
       label: 'OpenRouter Mistral Nemo (OpenRouter)',
       provider: 'OpenRouter',
       maxTokenAllowed: 8000,
+      free: false,
     },
     {
       name: 'qwen/qwen-110b-chat',
       label: 'OpenRouter Qwen 110b Chat (OpenRouter)',
       provider: 'OpenRouter',
       maxTokenAllowed: 8000,
+      free: false,
     },
-    { name: 'cohere/command', label: 'Cohere Command (OpenRouter)', provider: 'OpenRouter', maxTokenAllowed: 4096 },
+    { name: 'cohere/command', label: 'Cohere Command (OpenRouter)', provider: 'OpenRouter', maxTokenAllowed: 4096, free: false },
   ];
 
   async getDynamicModels(
@@ -89,12 +96,16 @@ export default class OpenRouterProvider extends BaseProvider {
 
       return data.data
         .sort((a, b) => a.name.localeCompare(b.name))
-        .map((m) => ({
-          name: m.id,
-          label: `${m.name} - in:$${(m.pricing.prompt * 1_000_000).toFixed(2)} out:$${(m.pricing.completion * 1_000_000).toFixed(2)} - context ${Math.floor(m.context_length / 1000)}k`,
-          provider: this.name,
-          maxTokenAllowed: 8000,
-        }));
+        .map((m) => {
+          const isFree = (m.pricing.prompt === 0 && m.pricing.completion === 0) || m.name.toLowerCase().includes('free');
+          return {
+            name: m.id,
+            label: `${m.name} - in:$${(m.pricing.prompt * 1_000_000).toFixed(2)} out:$${(m.pricing.completion * 1_000_000).toFixed(2)} - context ${Math.floor(m.context_length / 1000)}k${isFree ? ' (Free)' : ''}`,
+            provider: this.name,
+            maxTokenAllowed: 8000,
+            free: isFree
+          };
+        });
     } catch (error) {
       console.error('Error getting OpenRouter models:', error);
       return [];

--- a/app/lib/modules/llm/types.ts
+++ b/app/lib/modules/llm/types.ts
@@ -6,6 +6,7 @@ export interface ModelInfo {
   label: string;
   provider: string;
   maxTokenAllowed: number;
+  free?: boolean;
 }
 
 export interface ProviderInfo {


### PR DESCRIPTION

**Description** :

Cette Pull Request ajoute une nouvelle fonctionnalité dans le composant `ModelSelector` : un filtre permettant d’afficher uniquement les modèles gratuits. Cela améliore l’expérience utilisateur en facilitant la recherche de modèles accessibles sans frais.

### ✨ Fonctionnalités

- **Interface `ModelSelector`** :  
  - Ajout d’une case à cocher *« Afficher uniquement les modèles gratuits »*.
  - Le filtre fonctionne en combinaison avec la recherche existante.

- **Mise à jour du type `ModelInfo`** :  
  - Ajout d’un champ optionnel `free?: boolean` pour identifier les modèles gratuits.

- **Amélioration du provider OpenRouter** :  
  - Détection automatique des modèles gratuits (via prix ou nom).
  - Les modèles gratuits sont étiquetés avec la mention “(Free)” pour une meilleure visibilité dans la liste.

### ✅ Tests effectués

- Vérification du bon fonctionnement du filtre dans l’UI.
- Les modèles avec `free: true` s’affichent correctement.
- Mise à jour des modèles statiques pour inclure le champ `free`.

